### PR TITLE
Fixed nan matrix in llt() method result

### DIFF
--- a/src/fast_gicp/cuda/fast_vgicp_cuda.cu
+++ b/src/fast_gicp/cuda/fast_vgicp_cuda.cu
@@ -214,7 +214,7 @@ bool FastVGICPCudaCore::optimize(const Eigen::Isometry3f& initial_guess, Eigen::
     Eigen::Matrix<float, 6, 1> J_loss;
     cublasGetVector(6, sizeof(float), thrust::raw_pointer_cast(J_loss_ptr), 1, J_loss.data(), 1);
 
-    Eigen::Matrix<float, 6, 1> delta = JJ.llt().solve(J_loss);
+    Eigen::Matrix<float, 6, 1> delta = JJ.ldlt().solve(J_loss);
 
     // update parameters
     x0.head<3>() = (Sophus::SO3f::exp(-delta.head<3>()) * Sophus::SO3f::exp(x0.head<3>())).log();


### PR DESCRIPTION
Sometimes llt() returning nan matrix and the program crashes.
I suggest replacing llt() (Cholesky decomposition) to ldlt() (robust Cholesky decomposition). 

This change helped me fix program crashes.