### PR TITLE
change boost::shared_ptr to pcl::shared_ptr

### DIFF
--- a/include/fast_gicp/gicp/experimental/fast_gicp_mp.hpp
+++ b/include/fast_gicp/gicp/experimental/fast_gicp_mp.hpp
@@ -63,7 +63,7 @@ private:
   Eigen::VectorXf loss_ls(const Eigen::Matrix<float, 6, 1>& x, Eigen::MatrixXf* J) const;
 
   template<typename PointT>
-  bool calculate_covariances(const boost::shared_ptr<const pcl::PointCloud<PointT>>& cloud, pcl::search::KdTree<PointT>& kdtree, std::vector<Matrix4, Eigen::aligned_allocator<Matrix4>>& covariances);
+  bool calculate_covariances(const pcl::shared_ptr<const pcl::PointCloud<PointT>>& cloud, pcl::search::KdTree<PointT>& kdtree, std::vector<Matrix4, Eigen::aligned_allocator<Matrix4>>& covariances);
 
 private:
   int num_threads_;

--- a/include/fast_gicp/gicp/experimental/fast_gicp_mp_impl.hpp
+++ b/include/fast_gicp/gicp/experimental/fast_gicp_mp_impl.hpp
@@ -222,7 +222,7 @@ Eigen::VectorXf FastGICPMultiPoints<PointSource, PointTarget>::loss_ls(const Eig
 
 template<typename PointSource, typename PointTarget>
 template<typename PointT>
-bool FastGICPMultiPoints<PointSource, PointTarget>::calculate_covariances(const boost::shared_ptr<const pcl::PointCloud<PointT>>& cloud, pcl::search::KdTree<PointT>& kdtree, std::vector<Matrix4, Eigen::aligned_allocator<Matrix4>>& covariances) {
+bool FastGICPMultiPoints<PointSource, PointTarget>::calculate_covariances(const pcl::shared_ptr<const pcl::PointCloud<PointT>>& cloud, pcl::search::KdTree<PointT>& kdtree, std::vector<Matrix4, Eigen::aligned_allocator<Matrix4>>& covariances) {
   kdtree.setInputCloud(cloud);
   covariances.resize(cloud->size());
 


### PR DESCRIPTION
Starting with PCL 1.11, PCL uses `std::shared_ptr` and `std::weak_ptr` instead of the boost smart pointers. The change leverages type aliases included with the 1.10.0 release. But for compatibility with older PCL, we should do smooth transition with `pcl::shared_ptr` 