### PR TITLE
Feature/support point normal type

### DIFF
--- a/src/fast_gicp/gicp/fast_gicp.cpp
+++ b/src/fast_gicp/gicp/fast_gicp.cpp
@@ -3,3 +3,4 @@
 
 template class fast_gicp::FastGICP<pcl::PointXYZ, pcl::PointXYZ>;
 template class fast_gicp::FastGICP<pcl::PointXYZI, pcl::PointXYZI>;
+template class fast_gicp::FastGICP<pcl::PointNormal, pcl::PointNormal>;

--- a/src/fast_gicp/gicp/lsq_registration.cpp
+++ b/src/fast_gicp/gicp/lsq_registration.cpp
@@ -3,3 +3,4 @@
 
 template class fast_gicp::LsqRegistration<pcl::PointXYZ, pcl::PointXYZ>;
 template class fast_gicp::LsqRegistration<pcl::PointXYZI, pcl::PointXYZI>;
+template class fast_gicp::LsqRegistration<pcl::PointNormal, pcl::PointNormal>;


### PR DESCRIPTION
Fixes #83 by adding explicit template instantiations for the pcl::PointNormal type to the FastGICP and LsqRegistration classes, allowing them to work with this type