### PR TITLE
Feature/support getting fitness score through python api

### DIFF
--- a/src/python/main.cpp
+++ b/src/python/main.cpp
@@ -172,6 +172,7 @@ PYBIND11_MODULE(pygicp, m) {
     .def("swap_source_and_target", &LsqRegistration::swapSourceAndTarget)
     .def("get_final_hessian", &LsqRegistration::getFinalHessian)
     .def("get_final_transformation", &LsqRegistration::getFinalTransformation)
+    .def("get_fitness_score", [] (LsqRegistration& reg, const double max_range) { return reg.getFitnessScore(max_range); })
     .def("align",
       [] (LsqRegistration& reg, const Eigen::Matrix4f& initial_guess) { 
         pcl::PointCloud<pcl::PointXYZ> aligned;


### PR DESCRIPTION
Add support for getting `fitness score` through python api.

**Usage:**
```Python
# 1. function interface
import pygicp

target = # Nx3 numpy array
source = # Mx3 numpy array

# 2. class interface
# you may want to downsample the input clouds before registration
target = pygicp.downsample(target, 0.25)
source = pygicp.downsample(source, 0.25)

# pygicp.FastGICP has more or less the same interfaces as the C++ version
gicp = pygicp.FastGICP()
gicp.set_input_target(target)
gicp.set_input_source(source)
matrix = gicp.align()

# optional
gicp.set_num_threads(4)
gicp.set_max_correspondence_distance(1.0)
gicp.get_final_transformation()
gicp.get_final_hessian()
# here
gicp.get_fitness_score(max_range=1.0) 
```