### PR TITLE
use native gpu architecture to build when CUDA is enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ endif()
 
 ### CUDA ###
 if(BUILD_VGICP_CUDA)
-  set(CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
+  set(CUDA_NVCC_FLAGS "--expt-relaxed-constexpr -arch=native")
   add_definitions(-DUSE_VGICP_CUDA)
 
   cuda_add_library(fast_vgicp_cuda SHARED


### PR DESCRIPTION
fixes #91 

Nvcc didn't compile correctly the sources for my architecture and adding ` -arch=native` to `CUDA_NVCC_FLAGS` solved my issue

> When -arch=native is specified, nvcc detects the visible GPUs on the system and generates codes for them [...]

> [More details] https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html#options-for-steering-gpu-code-generation-gpu-architecture
