### PR TITLE
added pcl::PointNormal to FastGICPSingleThread

### DIFF
--- a/src/fast_gicp/gicp/fast_gicp_st.cpp
+++ b/src/fast_gicp/gicp/fast_gicp_st.cpp
@@ -3,3 +3,4 @@
 
 template class fast_gicp::FastGICPSingleThread<pcl::PointXYZ, pcl::PointXYZ>;
 template class fast_gicp::FastGICPSingleThread<pcl::PointXYZI, pcl::PointXYZI>;
+template class fast_gicp::FastGICPSingleThread<pcl::PointNormal, pcl::PointNormal>;


### PR DESCRIPTION
I encountered the same issue as was fixed by https://github.com/SMRT-AIST/fast_gicp/issues/83 except for the SingleThread version. I've made the same fix for this class, however this raises a few questions for me:
1. Why are predefined class templates required at all? (header only?)
2. Should `pcl::PointNormal` also be added to `fast_vgicp.cpp` and `fast_vgicp_cuda.cpp` so that they can be compiled with `pcl::PointNormal`?