### PR TITLE
Add build compatibility for ROS2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,18 @@ set(CMAKE_BUILD_TYPE "Release")
 find_package(PCL REQUIRED)
 find_package(Eigen3 REQUIRED)
 
+if(DEFINED ENV{ROS_VERSION})
+  set(ROS_VERSION $ENV{ROS_VERSION})
+endif()
+
 if(NOT BUILD_PYTHON_BINDINGS)
-  find_package(catkin)
+  if(${ROS_VERSION})
+    if(${ROS_VERSION} EQUAL 1)
+      find_package(catkin)
+    elseif (${ROS_VERSION} EQUAL 2)
+      find_package(ament_cmake)
+    endif()
+  endif()
 endif()
 
 find_package(OpenMP)
@@ -151,10 +161,28 @@ if(BUILD_test)
 endif()
 
 if(catkin_FOUND)
+  ###################################
+  ## catkin specific configuration ##
+  ###################################
   install(TARGETS ${PROJECT_NAME}
     LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
   
   install(DIRECTORY include/
     DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
     FILES_MATCHING PATTERN "*.hpp")
+elseif (ament_cmake_FOUND)
+  ##################################
+  ## ament specific configuration ##
+  ##################################
+  ament_export_include_directories(include)
+  ament_export_libraries(fast_gicp)
+  ament_package()
+
+  install(TARGETS ${PROJECT_NAME}
+    LIBRARY DESTINATION lib)
+
+  install(
+      DIRECTORY "include/"
+      DESTINATION include
+    )
 endif()

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>fast_gicp</name>
   <version>0.0.0</version>
   <description>A collection of fast point cloud registration implementations</description>
@@ -7,8 +8,20 @@
   <maintainer email="k.koide@aist.go.jp">k.koide</maintainer>
 
   <license>BSD</license>
+  <url type="website">https://github.com/SMRT-AIST/fast_gicp</url>
+  <url type="repository">https://github.com/SMRT-AIST/fast_gicp</url>
+  <url type="bugtracker">https://github.com/SMRT-AIST/fast_gicp/issues</url>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 1">catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_VERSION == 2">ament_cmake</buildtool_depend>
+
+  <build_depend>ros_environment</build_depend>
+
+  <depend>libpcl-all-dev</depend>
+  <depend>eigen</depend>
+
   <export>
+    <build_type condition="$ROS_VERSION == 1">catkin</build_type>
+    <build_type condition="$ROS_VERSION == 2">ament_cmake</build_type>
   </export>
 </package>


### PR DESCRIPTION
CMake now looks up the environment variable `$ROS_VERSION` which is set by the package `ros_environment` when a ROS or ROS2 installation is sourced. It then uses this value to determine whether to build for ROS1 or ROS2. Tested in `foxy` and `noetic` with `BUILD_VGICP_CUDA=ON` (should work for all currently-supported ROS versions).