### PR TITLE
Link against openmp library target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,9 @@ add_library(fast_gicp SHARED
 target_link_libraries(fast_gicp
   ${PCL_LIBRARIES}
 )
+if (OPENMP_FOUND)
+    target_link_libraries(fast_gicp OpenMP::OpenMP_CXX)
+endif ()
 target_include_directories(fast_gicp PUBLIC
   include
   ${PCL_INCLUDE_DIRS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,9 @@ target_link_libraries(fast_gicp
   ${PCL_LIBRARIES}
 )
 if (OPENMP_FOUND)
-    target_link_libraries(fast_gicp OpenMP::OpenMP_CXX)
+    if (TARGET OpenMP::OpenMP_CXX)
+        target_link_libraries(fast_gicp OpenMP::OpenMP_CXX)
+    endif ()
 endif ()
 target_include_directories(fast_gicp PUBLIC
   include


### PR DESCRIPTION
On macOS ARM, the code does not link because openmp libraries are missing. In my experience, different flags tend to be sufficient for different platforms.