### PR TITLE
fix: Add target installation for fast_vgicp_cuda compiled via `ament_cmake`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,9 @@ if(BUILD_VGICP_CUDA)
   if(catkin_FOUND)
     install(TARGETS fast_vgicp_cuda
       LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION})
+  elseif (ament_cmake_FOUND)
+    install(TARGETS fast_vgicp_cuda
+      LIBRARY DESTINATION lib)
   endif()
 endif()
 


### PR DESCRIPTION
This PR would add the missing target installation for `fast_vgicp_cuda` when compiling with `ament_cmake`.