### PR TITLE
CMakeLists.txt: Use CUDAToolkit instead of CUDA (deprecated) in find_…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,9 +33,9 @@ if (OPENMP_FOUND)
 endif()
 
 if(BUILD_VGICP_CUDA)
-  find_package(CUDA REQUIRED)
-  include_directories(${CUDA_INCLUDE_DIRS})
-  link_directories(${CUDA_LIBRARY_DIRS})
+  find_package(CUDAToolkit REQUIRED)
+  include_directories(${CUDAToolkit_INCLUDE_DIRS})
+  link_directories(${CUDAToolkit_LIBRARY_DIR})
 endif()
 
 ###################################


### PR DESCRIPTION
…package

Fixes,

```
CMake Warning (dev) at third_party/fast_gicp/CMakeLists.txt:36 (find_package):
  Policy CMP0146 is not set: The FindCUDA module is removed.  Run "cmake
  --help-policy CMP0146" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at .toolchain/c97040d85c983530acbe2e02c2327d0db40f6e7acb4dd8cbc280076c92c33ccf/sysroot/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find CUDA (missing: CUDA_TOOLKIT_ROOT_DIR CUDA_INCLUDE_DIRS
  CUDA_CUDART_LIBRARY) (found version "11.8")
Call Stack (most recent call first):
  .toolchain/c97040d85c983530acbe2e02c2327d0db40f6e7acb4dd8cbc280076c92c33ccf/sysroot/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
  .toolchain/c97040d85c983530acbe2e02c2327d0db40f6e7acb4dd8cbc280076c92c33ccf/sysroot/share/cmake-3.27/Modules/FindCUDA.cmake:1291 (find_package_handle_standard_args)
  third_party/fast_gicp/CMakeLists.txt:36 (find_package)
```