### PR TITLE
Fixed accumulation phase where one point was tried to accumulate multiple times

### DIFF
--- a/src/fast_gicp/cuda/gaussian_voxelmap.cu
+++ b/src/fast_gicp/cuda/gaussian_voxelmap.cu
@@ -100,10 +100,6 @@ struct accumulate_points_kernel {
       const thrust::pair<Eigen::Vector3i, int>& bucket = thrust::raw_pointer_cast(buckets_ptr)[bucket_index];
 
       if (equal(bucket.first, coord)) {
-        if (bucket.second < 0) {
-          break;
-        }
-
         int& num_points = thrust::raw_pointer_cast(num_points_ptr)[bucket.second];
         Eigen::Vector3f& voxel_mean = thrust::raw_pointer_cast(voxel_means_ptr)[bucket.second];
         Eigen::Matrix3f& voxel_cov = thrust::raw_pointer_cast(voxel_covs_ptr)[bucket.second];
@@ -115,6 +111,7 @@ struct accumulate_points_kernel {
         for (int j = 0; j < 9; j++) {
           atomicAdd(voxel_cov.data() + j, cov.data()[j]);
         }
+        break;
       }
     }
   }
@@ -143,6 +140,7 @@ struct accumulate_points_kernel {
         for (int j = 0; j < 9; j++) {
           atomicAdd(voxel_cov.data() + j, cov.data()[j]);
         }
+        break;
       }
     }
   }


### PR DESCRIPTION
Breaking the loop of the accumulation phase when the corresponding voxel for the point is found. Without it, the point was attempted to accumulate up to max_bucket_scan_count times, once to correct the voxel successfully, and the rest to various other voxels where it was rejected due to a comparison of the voxel coordinates. The problem is with points assigned to voxel \[0, 0, 0\], as the empty bins are marked as coords \[0, 0, 0\] and -1 table index. So when a point normally assigned to voxel \[0,0,0\] is tried to accumulate to an empty bin, then CUDA access memory is thrown.